### PR TITLE
Corrected stack for ScanResultTopicARN

### DIFF
--- a/post-scan-actions/aws-nodejs-securityhub-integration/README.md
+++ b/post-scan-actions/aws-nodejs-securityhub-integration/README.md
@@ -17,7 +17,7 @@ AWSACCOUNTNO: Provide your aws account ID
 AWSSecurityHubARN: arn:aws:securityhub:<region>:<aws acc no>:product/<aws acc no>/default
 
 
-3.	Copy ScanResultTopicArn from scanner cloudformation stack output. This is the same ARN that we have used in previous step for Quarantine and promote object.
+3.	Copy ScanResultTopicArn from storage cloudformation stack output. This is the same ARN that we have used in previous step for Quarantine and promote object.
 
  
 4.	Enter ScanResultTopicARN to serverless application parameter and proceed to Deploy


### PR DESCRIPTION
# ScanResultTopicARN is from Storage stack and not Scanner Stack.

## Change Summary
Updated docs.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
    - [x] Updated accordingly
    - [ ] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
